### PR TITLE
Use pnpm recomendation of running install after the cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         version: ${{ steps.resolved-pnpm.outputs.version }}
-        run_install: "{ args: ['${{ inputs.args }}'] }"
+        run_install: false
     - name: 'Setup node and the cache for pnpm'
       # this action aliases the major to the latest full version 
       # https://github.com/actions/setup-node/tags
@@ -119,3 +119,6 @@ runs:
         cache: 'pnpm'
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.node-registry-url }}
+    - name: 'Install dependencies'
+      shell: 'bash'
+      run: pnpm install ${{ inputs.args }}


### PR DESCRIPTION
https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

Port of https://github.com/NullVoxPopuli/action-setup-pnpm/pull/14 from @patricklx 