### PR TITLE
Change default node-version-file to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Allows changing the `node-version` passed to `actions/setup-node`.
     node-version: 18
 ```
 
+### `node-version-file`
+
+Allows changing the `node-version-file` passed to `actions/setup-node`.
+
+The default has changed from `actions/setup-node`'s `''` to `'package.json'`, enabling easy volta usage with 0 configuration for consumers of `wyvox/action-setup-pnpm`.
+_not_ providing a volta config also have 0 consequence.
+
+```yaml
+- uses: wyvox/action-setup-pnpm@v2
+  with:
+    node-version-file: '.node-version'
+```
+
 ### `node-registry-url`
 
 Allows changing the `registry-url` passed to `actions/setup-node`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ steps:
   - uses: pnpm/action-setup@v2
     with:
       version: 8
-  - uses: actions/setup-node@v3
+  - uses: actions/setup-node@v4
     with:
       cache: 'pnpm'
   - run: pnpm install

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The default has changed from `actions/setup-node`'s `''` to `'package.json'`, en
 _not_ providing a volta config also have 0 consequence.
 
 ```yaml
-- uses: wyvox/action-setup-pnpm@v2
+- uses: wyvox/action-setup-pnpm@v3
   with:
     node-version-file: '.node-version'
 ```

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
     #     Note also that volta's action does not have formal support for pnpm, nor its cache.
     # - does not install pnpm
     - name: 'Setup node and the cache for pnpm'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: 'pnpm'
         # If specified, takes precedence over node-version-file

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   node-version:
     description: "Override the default node version, or override what is specified in your project's volta config"
     required: false
+  node-version-file: 
+    description: "Override where the default node version is read from. By default this reads from package.json, which includes support for volta.node. Specifying node-version will override this"
+    required: false
+    default: 'package.json'
   node-registry-url:
     description: "Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN."
     required: false
@@ -121,7 +125,10 @@ runs:
       uses: actions/setup-node@v3
       with:
         cache: 'pnpm'
+        # If specified, takes precedence over node-version-file
         node-version: ${{ inputs.node-version }}
+        # Default node version read from package.json, but can be changed by passing in inputs.node-version-file
+        node-version-file: ${{ inputs.node-version-file }}
         registry-url: ${{ inputs.node-registry-url }}
 
     # It's only efficient to install dependencies

--- a/package.json
+++ b/package.json
@@ -6,8 +6,5 @@
 	},
 	"devDependencies": {
 		"prettier": "^2.8.4"
-	},
-	"volta": {
-		"node": "18.18.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
 	},
 	"devDependencies": {
 		"prettier": "^2.8.4"
+	},
+	"volta": {
+		"node": "18.18.0"
 	}
 }


### PR DESCRIPTION
In the wake of https://github.com/nodejs/node/issues/49911
I noticed that `actions/setup-node` doesn't _inherently_ support volta by default. It requires that `node-version-file` is set, which this PR changes to be the package.json, since the stated goal of this action is to easily support volta and package.json configs out of the box without configuration.

Tested here: https://github.com/NullVoxPopuli/actions-testing/actions/workflows/testing.yml
(and compared with various other environment scenarios)


Ran in to this: https://github.com/actions/setup-node/issues/864
which this repo suffers from