### PR TITLE
Update pnpm/action-setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
     # - no support for cache 
     #   (that's provided by setup-node)
     - name: 'Install pnpm'
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
         version: ${{ steps.resolved-pnpm.outputs.version }}
         run_install: false


### PR DESCRIPTION
This PR bumps version of `pnpm/action-setup` as it runs on nodejs 16 and its being deprecated, which results in warnings:


Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.