### PR TITLE
Update GitHub Action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - 16
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check licenses
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./
       - name: Install licensed tool

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.4.0
         with:
           source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v3 to v6 in `ci.yml` and `license.yml`
- Update `actions/publish-action` from v0.2.2 to v0.4.0 in `sync-release.yml`

## Test plan
- [ ] Verify CI workflow runs successfully with `actions/checkout@v6`
- [ ] Verify license workflow runs successfully with `actions/checkout@v6`
- [ ] Verify sync-release workflow is correct with `actions/publish-action@v0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)